### PR TITLE
Access web service through ingress gateway

### DIFF
--- a/.istio/4-ingress-gateway.yaml
+++ b/.istio/4-ingress-gateway.yaml
@@ -11,7 +11,8 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - "*"   # Domain name of the external website
+    - "*.railsevents.local"   # Domain name of the external website
+    - "railsevents.local"
 ---
 kind: VirtualService
 apiVersion: networking.istio.io/v1alpha3
@@ -20,7 +21,7 @@ metadata:
   namespace: default
 spec:
   hosts:      # which incoming host are we applying the proxy rules to???
-    - "*" # Copy the value in the gateway hosts - usually a Domain Name
+    - "railsevents.local" # Copy the value in the gateway hosts - usually a Domain Name
   gateways:
     - ingress-gateway-configuration
   http:

--- a/.istio/4-ingress-gateway.yaml
+++ b/.istio/4-ingress-gateway.yaml
@@ -60,3 +60,6 @@ spec:
     - labels:
         version: experimental
       name: experimental
+  trafficPolicy:
+    outlierDetection:
+      maxEjectionPercent: 100

--- a/.istio/4-ingress-gateway.yaml
+++ b/.istio/4-ingress-gateway.yaml
@@ -6,21 +6,21 @@ spec:
   selector:
     istio: ingressgateway # use Istio default gateway implementation
   servers:
-    - port:
-        number: 80
-        name: http
-        protocol: HTTP
-      hosts:
-        - "*"
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"   # Domain name of the external website
 ---
 kind: VirtualService
 apiVersion: networking.istio.io/v1alpha3
 metadata:
-  name: rails-events-virtual-service
+  name: rails-events-app-virtual-service
   namespace: default
 spec:
-  hosts: # which incoming host are we applying the proxy rules to???
-    - "*"
+  hosts:      # which incoming host are we applying the proxy rules to???
+    - "*" # Copy the value in the gateway hosts - usually a Domain Name
   gateways:
     - ingress-gateway-configuration
   http:

--- a/.istio/4-ingress-gateway.yaml
+++ b/.istio/4-ingress-gateway.yaml
@@ -4,14 +4,14 @@ metadata:
   name: ingress-gateway-configuration
 spec:
   selector:
-    istio: ingressgateway # use Istio default gateway implementation
+    istio: ingressgateway
   servers:
   - port:
       number: 80
       name: http
       protocol: HTTP
     hosts:
-    - "*.railsevents.local"   # Domain name of the external website
+    - "*.railsevents.local"
     - "railsevents.local"
 ---
 kind: VirtualService
@@ -20,15 +20,31 @@ metadata:
   name: rails-events-app-virtual-service
   namespace: default
 spec:
-  hosts:      # which incoming host are we applying the proxy rules to???
-    - "railsevents.local" # Copy the value in the gateway hosts - usually a Domain Name
+  hosts:
+    - "railsevents.local"
   gateways:
     - ingress-gateway-configuration
   http:
     - route:
         - destination:
             host: rails-events-app
-          weight: 100
+            subset: original
+---
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: rails-events-app-canary-test-virtual-service
+  namespace: default
+spec:
+  hosts:
+    - "*.railsevents.local"
+  gateways:
+    - ingress-gateway-configuration
+  http:
+      - route:
+        - destination:
+            host: rails-events-app
+            subset: experimental
 ---
 kind: DestinationRule
 apiVersion: networking.istio.io/v1alpha3
@@ -37,3 +53,10 @@ metadata:
   namespace: default
 spec:
   host: rails-events-app
+  subsets:
+    - labels:
+        version: original
+      name: original
+    - labels:
+        version: experimental
+      name: experimental

--- a/.istio/4-ingress-gateway.yaml
+++ b/.istio/4-ingress-gateway.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: ingress-gateway-configuration
+spec:
+  selector:
+    istio: ingressgateway # use Istio default gateway implementation
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+kind: VirtualService
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: rails-events-virtual-service
+  namespace: default
+spec:
+  hosts: # which incoming host are we applying the proxy rules to???
+    - "*"
+  gateways:
+    - ingress-gateway-configuration
+  http:
+    - route:
+        - destination:
+            host: rails-events-app
+          weight: 100
+---
+kind: DestinationRule
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: rails-events-app-destination-rule
+  namespace: default
+spec:
+  host: rails-events-app

--- a/.istio/kiali-secret.yaml
+++ b/.istio/kiali-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: kiali
+  namespace: istio-system
+  labels:
+    app: kiali
+data:
+  username: YWRtaW4=
+  passphrase: YWRtaW4=

--- a/.istio/label-default-namespace.yaml
+++ b/.istio/label-default-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled
+  name: default

--- a/.k8s/rails-events-app.yaml
+++ b/.k8s/rails-events-app.yaml
@@ -36,5 +36,4 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 3000
-  type: LoadBalancer
+  type: ClusterIP

--- a/.k8s/rails-events-app.yaml
+++ b/.k8s/rails-events-app.yaml
@@ -36,4 +36,5 @@ spec:
   ports:
     - name: http
       port: 80
-  type: ClusterIP
+      targetPort: 3000
+  type: LoadBalancer

--- a/.k8s/rails-events-app.yaml
+++ b/.k8s/rails-events-app.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: rails-events-app
+        version: original
     spec:
       containers:
         - name: rails-events-app
@@ -25,6 +26,37 @@ spec:
           envFrom:
             - configMapRef:
                 name: rails-events-config
+          imagePullPolicy: Always
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rails-events-app-canary-test
+spec:
+  selector:
+    matchLabels:
+      app: rails-events-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: rails-events-app
+        version: experimental
+    spec:
+      containers:
+        - name: rails-events-app
+          image: basilmawejje/rails-events:v1
+          resources:
+            requests:
+              memory: 300Mi
+              cpu: 100m
+            limits:
+              memory: 500Mi
+              cpu: 200m
+          envFrom:
+            - configMapRef:
+                name: rails-events-config
+          imagePullPolicy: Always
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Problem

What is the problem you're solving or feature you're implementing?
* Enhance local development using k8s and istio.

## Solution

Describe the feature or bug fix -- what's changing?
* Setup canary with guaranteed QoS requirement.
* Ensure mutual TLS (mtls) works in permissive mode.
* Enabled circuit breakers using mostly default config options (shown in attached screenshots below)
* Add subdomain routing via ingress-gateway in istio. This enables us to connect to the original and experimental subdomains listed in the `Details` section below.

## Details

* Apps now accessible locally via `railsevents.local:PORT_NUMBER` and `experimental.railsevents.local:PORT_NUMBER`

### Current state of services in kiali shown below:
<img width="1438" alt="Screenshot 2024-06-20 at 13 10 56" src="https://github.com/BasilMawejje/rails-events/assets/26635598/4f8597cc-7ead-495f-b85c-1bdb512ea908">

<img width="1439" alt="Screenshot 2024-06-25 at 14 13 44" src="https://github.com/BasilMawejje/rails-events/assets/26635598/7486c8c5-fa97-4725-85c0-4f7b187085bc">
