### PR TITLE
Add terminal access to run adhoc tasks in rails console

### DIFF
--- a/.k8s/maintainance-console.yaml
+++ b/.k8s/maintainance-console.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: terminal
+spec:
+  containers:
+  - name: terminal
+    image: basilmawejje/rails-events:v1
+    resources:
+            requests:
+              memory: 150Mi
+              cpu: 50m
+            limits:
+              memory: 250Mi
+              cpu: 100m
+    envFrom:
+        - configMapRef:
+            name: rails-events-config


### PR DESCRIPTION
## Problem

What is the problem you're solving or feature you're implementing?
* Add terminal access for debugging/ running adhoc tasks.

## Solution

Describe the feature or bug fix -- what's changing?
* Create a pod with minimal requirements that will run a terminal using the command below:
`kubectl exec -it terminal rails console`

## Details

<img width="1000" alt="Screenshot 2024-06-26 at 12 36 51" src="https://github.com/BasilMawejje/rails-events/assets/26635598/8bc5298c-438e-4242-95ed-ea7cd6571ed6">

<img width="1437" alt="Screenshot 2024-06-26 at 13 01 08" src="https://github.com/BasilMawejje/rails-events/assets/26635598/e6e4a3e9-9629-4d39-9897-410254cfc782">